### PR TITLE
Allow directory slash for login callback url

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -74,7 +74,7 @@ export default defineNuxtPlugin(() => {
   addRouteMiddleware('auth', async (to) => {
     const {user, authConfig, setBearerToken, setRefreshToken} = await useAuth()
 
-    if (to.path === authConfig.redirect.callback) {
+    if (to.path === authConfig.redirect.callback || to.path === authConfig.redirect.callback + '/') {
       const queryParams = new URLSearchParams(to.query.toString());
       if (queryParams.has('error')) {
         return navigateTo(authConfig.redirect.login)


### PR DESCRIPTION
If the web server automatically end the URL with a slash, the callback url is no longer recognized. 